### PR TITLE
Unify logging across tests

### DIFF
--- a/hype-caplet/src/main/resources/logback-test.xml
+++ b/hype-caplet/src/main/resources/logback-test.xml
@@ -1,0 +1,1 @@
+../../../../logback-test.xml

--- a/hype-common/src/test/resources/logback-test.xml
+++ b/hype-common/src/test/resources/logback-test.xml
@@ -1,0 +1,1 @@
+../../../../logback-test.xml

--- a/hype-gcs/src/test/resources/logback-test.xml
+++ b/hype-gcs/src/test/resources/logback-test.xml
@@ -1,0 +1,1 @@
+../../../../logback-test.xml

--- a/hype-submitter/pom.xml
+++ b/hype-submitter/pom.xml
@@ -52,11 +52,6 @@
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>1.7.5</version>
-    </dependency>
 
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -80,11 +75,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/hype-submitter/src/test/resources/logback-test.xml
+++ b/hype-submitter/src/test/resources/logback-test.xml
@@ -1,0 +1,1 @@
+../../../../logback-test.xml

--- a/hype-testing/src/test/resources/logback-test.xml
+++ b/hype-testing/src/test/resources/logback-test.xml
@@ -1,0 +1,1 @@
+../../../../logback-test.xml

--- a/logback-test.xml
+++ b/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <root level="info">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+      <name>STDOUT</name>
+      <encoder>
+        <pattern>
+          %gray(%d{HH:mm:ss.SSS}) %highlight(| %-5level| %-20logger{0}) %green(|>) %msg%n
+        </pattern>
+      </encoder>
+    </appender>
+  </root>
+
+  <logger name="com.spotify.apollo" level="warn"/>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </modules>
 
   <properties>
-    <flo.version>0.0.8</flo.version>
+    <flo.version>0.0.9</flo.version>
     <grpc.version>1.0.3</grpc.version>
     <gcloud.version>0.11.1-beta</gcloud.version>
     <gcloud-alpha.version>0.11.1-alpha</gcloud-alpha.version>
@@ -167,7 +167,7 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.1.7</version>
+        <version>1.2.3</version>
       </dependency>
 
       <dependency>
@@ -190,6 +190,14 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
   <build>
     <plugins>


### PR DESCRIPTION
This uses a shared logback-classic configuration for all tests.