### PR TITLE
Parallel staging

### DIFF
--- a/hype-gcs/src/test/java/com/spotify/hype/gcs/ManifestLoaderTest.java
+++ b/hype-gcs/src/test/java/com/spotify/hype/gcs/ManifestLoaderTest.java
@@ -61,8 +61,8 @@ public class ManifestLoaderTest {
         StagingUtil.stageClasspathElements(testFiles, stagingLocation);
 
     RunManifest manifest = new RunManifestBuilder()
-        .continuation(stagedPackages.get(0).getName())
-        .files(stagedPackages.stream().map(StagedPackage::getName).collect(toList()))
+        .continuation(stagedPackages.get(0).name())
+        .files(stagedPackages.stream().map(StagedPackage::name).collect(toList()))
         .build();
 
     Path manifestFile = stagingPath.resolve("manifest.txt");

--- a/hype-gcs/src/test/java/com/spotify/hype/gcs/StagingUtilTest.java
+++ b/hype-gcs/src/test/java/com/spotify/hype/gcs/StagingUtilTest.java
@@ -82,8 +82,8 @@ public class StagingUtilTest {
     assertThat(stagedPackages, hasSize(1));
     StagingUtil.StagedPackage stagedPackage = stagedPackages.get(0);
 
-    assertThat(stagedPackage.getName().matches(md5HashPattern()), is(true));
-    assertThat(stagedPackage.getLocation().matches(".+/" + md5HashPattern()), is(true));
+    assertThat(stagedPackage.name().matches(md5HashPattern()), is(true));
+    assertThat(stagedPackage.location().matches(".+/" + md5HashPattern()), is(true));
   }
 
   private String md5HashPattern() {

--- a/hype-submitter/src/main/java/com/spotify/hype/Submitter.java
+++ b/hype-submitter/src/main/java/com/spotify/hype/Submitter.java
@@ -187,20 +187,20 @@ public class Submitter implements Closeable {
         this.stagingLocation.toString());
 
     final Optional<StagedPackage> stagedContinuationPackage = stagedPackages.stream()
-        .filter(p -> p.getName().contains(continuationFileName))
+        .filter(p -> p.name().contains(continuationFileName))
         .findFirst();
 
     if (!stagedContinuationPackage.isPresent()) {
       throw new RuntimeException();
     }
 
-    final URI uri = URI.create(stagedContinuationPackage.get().getLocation());
+    final URI uri = URI.create(stagedContinuationPackage.get().location());
     final String cont = Paths.get(uri).getFileName().toString();
 
     // todo: move manifest creation into StagingUtil
     final RunManifest manifest = new RunManifestBuilder()
         .continuation(cont)
-        .classPathFiles(stagedPackages.stream().map(StagedPackage::getName).collect(toList()))
+        .classPathFiles(stagedPackages.stream().map(StagedPackage::name).collect(toList()))
         // todo: files
         .build();
     try {


### PR DESCRIPTION
We can optimize the staging process by leveraging that Hype encourages usage patterns with multiple submission from the same JVM. This PR adds:

- Parallel uploads - files are uploaded on a thread pool
- A static cache for uploaded files - don't try to upload the same files multiple times

# Rough stats

Comparing upload times before and after this checks shows that for the case where the classpath has not changed, the old code took ~10s to check 69 files, while the new code takes ~1-2s. The parallel checks give us a speedup when reading local files and comparing them to already staged files (2 seconds), and the cache removes redundant checks when only single files are new (<1 second).

## Before

### Upload 0 (fresh JVM)

```
18:01:55.068 | INFO | StagingUtil |> Uploading 69 files to staging location gs://hype-staging-test to prepare for execution.
18:02:05.956 | INFO | StagingUtil |> Uploading complete: 1 files newly uploaded, 68 files cached
```

### Upload 1+ - re-checking same files

```
18:02:18.634 | INFO | StagingUtil |> Uploading 69 files to staging location gs://hype-staging-test to prepare for execution.
18:02:29.489 | INFO | StagingUtil |> Uploading complete: 1 files newly uploaded, 68 files cached
```

### Parallel upload

```
18:03:16.683 | INFO | StagingUtil |> Uploading 69 files to staging location gs://hype-staging-test to prepare for execution.
18:03:16.710 | INFO | StagingUtil |> Uploading 69 files to staging location gs://hype-staging-test to prepare for execution.
18:03:16.728 | INFO | StagingUtil |> Uploading 69 files to staging location gs://hype-staging-test to prepare for execution.
18:03:16.733 | INFO | StagingUtil |> Uploading 69 files to staging location gs://hype-staging-test to prepare for execution.
18:03:26.340 | INFO | StagingUtil |> Uploading complete: 1 files newly uploaded, 68 files cached
18:03:26.462 | INFO | StagingUtil |> Uploading complete: 1 files newly uploaded, 68 files cached
18:03:26.634 | INFO | StagingUtil |> Uploading complete: 1 files newly uploaded, 68 files cached
18:03:26.642 | INFO | StagingUtil |> Uploading complete: 1 files newly uploaded, 68 files cached
```

## After

### Upload 0 (fresh JVM) - with parallel checks

```
18:17:27.233 | INFO | StagingUtil |> Uploading 69 files to staging location gs://hype-staging-test to prepare for execution.
18:17:29.043 | INFO | StagingUtil |> Uploading complete: 1 files newly uploaded, 68 files cached
```

### Upload 1+ - with cached checks

```
18:18:01.662 | INFO | StagingUtil |> Uploading 69 files to staging location gs://hype-staging-test to prepare for execution.
18:18:02.549 | INFO | StagingUtil |> Uploading complete: 1 files newly uploaded, 68 files cached
```

### Parallel uploads - with cached checks

```
18:18:50.355 | INFO | StagingUtil |> Uploading 69 files to staging location gs://hype-staging-test to prepare for execution.
18:18:50.356 | INFO | StagingUtil |> Uploading 69 files to staging location gs://hype-staging-test to prepare for execution.
18:18:50.360 | INFO | StagingUtil |> Uploading 69 files to staging location gs://hype-staging-test to prepare for execution.
18:18:50.360 | INFO | StagingUtil |> Uploading 69 files to staging location gs://hype-staging-test to prepare for execution.
18:18:51.067 | INFO | StagingUtil |> Uploading complete: 1 files newly uploaded, 68 files cached
18:18:51.102 | INFO | StagingUtil |> Uploading complete: 1 files newly uploaded, 68 files cached
18:18:51.152 | INFO | StagingUtil |> Uploading complete: 1 files newly uploaded, 68 files cached
18:18:51.188 | INFO | StagingUtil |> Uploading complete: 1 files newly uploaded, 68 files cached
```