### PR TITLE
Add logging sidecar

### DIFF
--- a/hype-run/src/main/java/com/spotify/hype/stub/TeePrintStream.java
+++ b/hype-run/src/main/java/com/spotify/hype/stub/TeePrintStream.java
@@ -1,0 +1,46 @@
+/*
+ * -\-\-
+ * hype
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ *  --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.hype.stub;import java.io.PrintStream;
+
+/**
+ * Print Stream which will write to 2 separate streams.
+ */
+class TeePrintStream extends PrintStream {
+
+  private final PrintStream out;
+
+  TeePrintStream(PrintStream out1, PrintStream out2) {
+    super(out1);
+    this.out = out2;
+  }
+
+  public void write(byte buf[], int off, int len) {
+    try {
+      super.write(buf, off, len);
+      out.write(buf, off, len);
+    } catch (Exception ignored) {}
+  }
+
+  public void flush() {
+    super.flush();
+    out.flush();
+  }
+}

--- a/hype-submitter/src/main/java/com/spotify/hype/model/LoggingSidecar.java
+++ b/hype-submitter/src/main/java/com/spotify/hype/model/LoggingSidecar.java
@@ -1,9 +1,9 @@
-/*-
+/*
  * -\-\-
- * hype-submitter
+ * hype
  * --
  * Copyright (C) 2016 - 2017 Spotify AB
- * --
+ *  --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,33 +18,23 @@
  * -/-/-
  */
 
-package com.spotify.hype.runner;
+package com.spotify.hype.model;
 
-import com.spotify.hype.model.LoggingSidecar;
-import com.spotify.hype.model.RunEnvironment;
-import com.spotify.hype.model.StagedContinuation;
+
 import io.norberg.automatter.AutoMatter;
-import javax.annotation.Nullable;
+import java.util.List;
 
 @AutoMatter
-public interface RunSpec {
+public interface LoggingSidecar {
 
-  RunEnvironment runEnvironment();
-  StagedContinuation stagedContinuation();
   String image();
-  @Nullable
-  LoggingSidecar loggingSidecar();
+  List<String> args();
 
-  static RunSpec runSpec(
-      RunEnvironment runEnvironment,
-      StagedContinuation stagedContinuation,
-      String image,
-      LoggingSidecar loggingSidecar) {
-    return new RunSpecBuilder()
-        .runEnvironment(runEnvironment)
-        .stagedContinuation(stagedContinuation)
+  static LoggingSidecar loggingSidecar(final String image, final List<String> args) {
+    return new LoggingSidecarBuilder()
         .image(image)
-        .loggingSidecar(loggingSidecar)
+        .args(args)
         .build();
   }
+
 }

--- a/hype-submitter/src/test/java/com/spotify/hype/runner/KubernetesDockerRunnerTest.java
+++ b/hype-submitter/src/test/java/com/spotify/hype/runner/KubernetesDockerRunnerTest.java
@@ -222,7 +222,7 @@ public class KubernetesDockerRunnerTest {
 
   private Pod createPod(RunEnvironment env) {
     StagedContinuation cont = StagedContinuation.stagedContinuation(MANIFEST_PATH, MANIFEST);
-    RunSpec runSpec = RunSpec.runSpec(env, cont, "busybox:1");
+    RunSpec runSpec = RunSpec.runSpec(env, cont, "busybox:1", null);
 
     return runner.createPod(runSpec);
   }

--- a/hype-submitter_2.11/src/main/scala/com/spotify/hype/Example.scala
+++ b/hype-submitter_2.11/src/main/scala/com/spotify/hype/Example.scala
@@ -6,7 +6,6 @@ import com.spotify.hype.model.VolumeRequest._
 import scala.collection.JavaConverters._
 
 private object Example {
-
   def main(args: Array[String]): Unit = {
 
     val env = RunEnvironment()
@@ -27,12 +26,14 @@ private object Example {
     val slow10Gi = volumeRequest("slow", "10Gi")
 
     val submitter = GkeSubmitter("datawhere-test", "us-east1-d", "hype-test", "gs://hype-test/staging")
+    val loggingSidecar = LoggingSidecar("us.gcr.io/datawhere-test/hype-log-slack:1")
 
-    val ret = submitter.submit(fn, env.withMount(slow10Gi.mountReadWrite("/usr/share/volume")))
+    val ret = submitter.submit(fn, env.withMount(slow10Gi.mountReadWrite("/usr/share/volume")), loggingSidecar)
     println(ret)
 
     for (i <- (0 to 10).par) {
       submitter.submit(fn, env.withMount(slow10Gi.mountReadOnly("/usr/share/volume")))
     }
   }
+
 }

--- a/hype-submitter_2.11/src/main/scala/com/spotify/hype/HFn.scala
+++ b/hype-submitter_2.11/src/main/scala/com/spotify/hype/HFn.scala
@@ -1,5 +1,9 @@
 package com.spotify.hype
 
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.Duration
+
 trait HFn[T] extends Serializable {
 
   /**

--- a/hype-submitter_2.11/src/main/scala/com/spotify/hype/HypeSubmitter.scala
+++ b/hype-submitter_2.11/src/main/scala/com/spotify/hype/HypeSubmitter.scala
@@ -1,13 +1,13 @@
 package com.spotify.hype
 
-import com.spotify.hype.model.RunEnvironment
+import com.spotify.hype.model.{LoggingSidecar, RunEnvironment}
 
 trait HypeSubmitter {
 
   protected def submitter: Submitter
 
-  def submit[T](hfn: HFn[T], env: RunEnvironment): T = {
-    submitter.runOnCluster(hfn.run, env, hfn.image)
+  def submit[T](hfn: HFn[T], env: RunEnvironment, loggingSidecar: LoggingSidecar=null): T = {
+    submitter.runOnCluster(hfn.run, env, hfn.image, loggingSidecar)
   }
 
   protected def setupShutdown(submitter: Submitter): Submitter = {

--- a/hype-submitter_2.11/src/main/scala/com/spotify/hype/package.scala
+++ b/hype-submitter_2.11/src/main/scala/com/spotify/hype/package.scala
@@ -2,6 +2,8 @@ package com.spotify
 
 import scala.language.implicitConversions
 
+import scala.collection.JavaConverters._
+
 package object hype {
 
   object RunEnvironment {
@@ -16,6 +18,11 @@ package object hype {
   object VolumeRequest {
     def apply(name: String, mountPath: String): model.VolumeRequest =
       model.VolumeRequest.volumeRequest(name, mountPath)
+  }
+
+  object LoggingSidecar {
+    def apply(image: String, args: List[String] = List()): model.LoggingSidecar =
+      model.LoggingSidecar.loggingSidecar(image, args.asJava)
   }
 
   implicit def fnToHfn[T](fn: util.Fn[T]): HFn[T] = HFn(fn.run())

--- a/hype-submitter_2.12/src/main/scala/com/spotify/hype/package.scala
+++ b/hype-submitter_2.12/src/main/scala/com/spotify/hype/package.scala
@@ -1,5 +1,7 @@
 package com.spotify
 
+import scala.collection.JavaConverters._
+
 package object hype {
 
   object RunEnvironment {
@@ -14,6 +16,11 @@ package object hype {
   object VolumeRequest {
     def apply(name: String, mountPath: String): model.VolumeRequest =
       model.VolumeRequest.volumeRequest(name, mountPath)
+  }
+
+  object LoggingSidecar {
+    def apply(image: String, args: List[String] = List()): model.LoggingSidecar =
+      model.LoggingSidecar.loggingSidecar(image, args.asJava)
   }
 
 }


### PR DESCRIPTION
@rouzwawi @yonromai

Not totally done, but wanted some initial feedback. This is tested and works though there are a couple problems with it.

For one, there is an obvious race condition that the main container could exit and we could kill the pod before the side container finishes sending out the logs. Since the side container is meant to never exit Im not sure if there is a correct solution. We could have it wait some amount of time after the main container exits before killing the pod but obviously there are no guarantees.

I also need to add proper testing.

