### PR TITLE
Disable retries for now

### DIFF
--- a/hype-submitter/src/main/java/com/spotify/hype/runner/KubernetesDockerRunner.java
+++ b/hype-submitter/src/main/java/com/spotify/hype/runner/KubernetesDockerRunner.java
@@ -246,7 +246,7 @@ public class KubernetesDockerRunner implements DockerRunner {
           .build();
 
       final PodSpec spec = new PodSpecBuilder()
-          .withRestartPolicy("OnFailure") // todo: max retry limit
+          .withRestartPolicy("Never") // todo: enable retries with max retry limit
           .addToContainers(container)
           .build();
 


### PR DESCRIPTION
@rouzwawi @yonromai 

Since hype is still very much in development retries are more of a burden than a feature. Runs very frequently fail due to bugs in the code and we have to manually stop the pods since there are retries. Lets disable for now and enable once things are more stable and we have proper retry limits.