### PR TITLE
Keep and re-use VolumeRequests

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ prepare some data, and then fork out to several parallel tasks that use the disk
        height="213"/>
 </p>
 
+## GCE Persistent Disk
+
 In this example, we're using a StorageClass for [GCE Persistent Disk] that we've already set up on
 our cluster.
 
@@ -264,6 +266,35 @@ was written to it from the `write` function.
 
 Coordinating metadata and parameters across multiple submissions should be just as trivial as
 passing values from function calls as arguments to other functions.
+
+### Volume re-use
+
+By default, the backing claim for a `VolumeRequest` on Kubernetes is deleted when the JVM 
+terminates. This can be overridden by using `.keepOnExit`.
+
+```scala
+val disk = VolumeRequest("gce-ssd-pd", "10Gi").keepOnExit
+```
+
+This is useful in use cases with larger volumes that take a significant amount of time to load,
+or when there's some sort of workflow orchestration around the Hype code that might run 
+different part separate JVM invocations.
+
+The volume claim id can be seen in the execution logs as:
+
+```
+> Created PersistentVolumeClaim hype-request-4fzih539 for VolumeRequest{id=hype-request-4fzih539, keep=true, spec=VolumeRequest.NewClaimRequest{storageClass=slow, size=10Gi}}
+```
+
+The claim id here is `"hype-request-4fzih539"` and it is marked `keep=true`. Note that the id is
+also part of the `VolumeRequest` value itself and can be accessed programmatically through
+`disk.id`.
+
+In order to re-use this volume claim in later runs, simply construct the `VolumeRequest` through:
+
+```scala
+val disk = ExistingVolume("hype-request-4fzih539")
+```
 
 # Environment Pod from YAML
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A library for seamlessly executing arbitrary JVM closures in [Docker] containers
   * [Leveraging implicits](#leveraging-implicits)
 - [Process overview](#process-overview)
 - [Persistent volumes](#persistent-volumes)
+  * [GCE Persistent Disk](#gce-persistent-disk)
+    + [Volume re-use](#volume-re-use)
 - [Environment Pod from YAML](#environment-pod-from-yaml)
 
 ---

--- a/hype-submitter/src/main/java/com/spotify/hype/model/VolumeRequest.java
+++ b/hype-submitter/src/main/java/com/spotify/hype/model/VolumeRequest.java
@@ -52,6 +52,10 @@ public interface VolumeRequest {
 
   static VolumeRequest volumeRequest(String storageClass, String size) {
     final String id = VOLUME_REQUEST_PREFIX + Util.randomAlphaNumeric(8);
+    return volumeRequest(id, storageClass, size);
+  }
+
+  static VolumeRequest volumeRequest(String id, String storageClass, String size) {
     return new VolumeRequestBuilder()
         .id(id)
         .keep(false) // new claims are deleted by default

--- a/hype-submitter/src/main/java/com/spotify/hype/model/VolumeRequest.java
+++ b/hype-submitter/src/main/java/com/spotify/hype/model/VolumeRequest.java
@@ -31,16 +31,50 @@ import io.norberg.automatter.AutoMatter;
 @AutoMatter
 public interface VolumeRequest {
 
+  String VOLUME_REQUEST_PREFIX = "hype-request-";
+
   String id();
-  String storageClass();
-  String size();
+  boolean keep();
+  RequestSpec spec();
+
+  interface RequestSpec { }
+
+  @AutoMatter
+  interface NewClaimRequest extends RequestSpec {
+    String storageClass();
+    String size();
+  }
+
+  @AutoMatter
+  interface ExistingClaimRequest extends RequestSpec {
+    String claimName();
+  }
 
   static VolumeRequest volumeRequest(String storageClass, String size) {
-    final String id = "request-" + Util.randomAlphaNumeric(8);
+    final String id = VOLUME_REQUEST_PREFIX + Util.randomAlphaNumeric(8);
     return new VolumeRequestBuilder()
         .id(id)
-        .storageClass(storageClass)
-        .size(size)
+        .keep(false) // new claims are deleted by default
+        .spec(new NewClaimRequestBuilder()
+            .storageClass(storageClass)
+            .size(size)
+            .build())
+        .build();
+  }
+
+  static VolumeRequest existingClaim(String claimName) {
+    return new VolumeRequestBuilder()
+        .id(claimName)
+        .keep(true) // do not delete existing claims
+        .spec(new ExistingClaimRequestBuilder()
+            .claimName(claimName)
+            .build())
+        .build();
+  }
+
+  default VolumeRequest keepOnExit() {
+    return VolumeRequestBuilder.from(this)
+        .keep(true)
         .build();
   }
 

--- a/hype-submitter/src/test/java/com/spotify/hype/runner/VolumeRepositoryTest.java
+++ b/hype-submitter/src/test/java/com/spotify/hype/runner/VolumeRepositoryTest.java
@@ -87,7 +87,7 @@ public class VolumeRepositoryTest {
   }
 
   @Test
-  public void createsNewVolumesClaim() throws Exception {
+  public void createsNewVolumeClaim() throws Exception {
     VolumeRequest request = VolumeRequest.volumeRequest("storage-class-name", "16Gi");
     PersistentVolumeClaim claim = volumeRepository.getClaim(request);
 
@@ -99,6 +99,14 @@ public class VolumeRepositoryTest {
     assertThat(
         claim.getSpec().getResources().getRequests(),
         hasEntry("storage", new Quantity("16Gi")));
+  }
+
+  @Test
+  public void createsNewVolumeClaimWithSpecificName() throws Exception {
+    VolumeRequest request = VolumeRequest.volumeRequest("the-claim", "storage-class-name", "16Gi");
+    PersistentVolumeClaim claim = volumeRepository.getClaim(request);
+
+    assertThat(claim.getMetadata().getName(), equalTo("the-claim"));
   }
 
   @Test

--- a/hype-submitter/src/test/java/com/spotify/hype/runner/VolumeRepositoryTest.java
+++ b/hype-submitter/src/test/java/com/spotify/hype/runner/VolumeRepositoryTest.java
@@ -1,0 +1,140 @@
+/*-
+ * -\-\-
+ * hype-submitter
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.hype.runner;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.spotify.hype.model.VolumeRequest;
+import io.fabric8.kubernetes.api.model.DoneablePersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VolumeRepositoryTest {
+
+  private static final String EXISTING_CLAIM = "hype-request-abc123";
+
+  @Rule public ExpectedException expect = ExpectedException.none();
+
+  @Mock KubernetesClient mockClient;
+  @Mock Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim> existingPvcResource;
+  @Mock Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim> nonExistingPvcResource;
+  @Mock PersistentVolumeClaim mockPvc;
+  @Mock MixedOperation< // euw
+      PersistentVolumeClaim,
+      PersistentVolumeClaimList,
+      DoneablePersistentVolumeClaim,
+      Resource<
+          PersistentVolumeClaim,
+          DoneablePersistentVolumeClaim>> pvcs;
+
+  @Captor ArgumentCaptor<PersistentVolumeClaim> createdPvc;
+  @Captor ArgumentCaptor<List<PersistentVolumeClaim>> deletedPvcs;
+
+  private VolumeRepository volumeRepository;
+
+  @Before
+  public void setUp() throws Exception {
+    volumeRepository = new VolumeRepository(mockClient);
+    when(mockClient.persistentVolumeClaims()).thenReturn(pvcs);
+    when(pvcs.withName(any())).thenAnswer(invocation ->
+        invocation.getArguments()[0].equals(EXISTING_CLAIM)
+        ? existingPvcResource : nonExistingPvcResource);
+    when(existingPvcResource.get()).thenReturn(mockPvc);
+    when(nonExistingPvcResource.get()).thenReturn(null);
+    when(pvcs.create(createdPvc.capture())).then(invocation -> createdPvc.getValue());
+    when(pvcs.delete(deletedPvcs.capture())).thenReturn(true);
+  }
+
+  @Test
+  public void createsNewVolumesClaim() throws Exception {
+    VolumeRequest request = VolumeRequest.volumeRequest("storage-class-name", "16Gi");
+    PersistentVolumeClaim claim = volumeRepository.getClaim(request);
+
+    assertThat(claim.getMetadata().getName(), equalTo(request.id()));
+    assertThat(
+        claim.getMetadata().getAnnotations(),
+        hasEntry(VolumeRepository.STORAGE_CLASS_ANNOTATION, "storage-class-name"));
+    assertThat(claim.getSpec().getAccessModes(), contains("ReadWriteOnce", "ReadOnlyMany"));
+    assertThat(
+        claim.getSpec().getResources().getRequests(),
+        hasEntry("storage", new Quantity("16Gi")));
+  }
+
+  @Test
+  public void returnsExistingClaim() throws Exception {
+    VolumeRequest request = VolumeRequest.existingClaim(EXISTING_CLAIM);
+    PersistentVolumeClaim claim = volumeRepository.getClaim(request);
+
+    assertThat(claim, is(mockPvc));
+  }
+
+  @Test
+  public void throwsWhenExistingClaimNotFound() throws Exception {
+    expect.expect(RuntimeException.class);
+    expect.expectMessage("Requested claim 'does-not-exist' not found");
+
+    VolumeRequest request = VolumeRequest.existingClaim("does-not-exist");
+    volumeRepository.getClaim(request);
+  }
+
+  @Test
+  public void cachesRequestClaims() throws Exception {
+    VolumeRequest request = VolumeRequest.volumeRequest("storage-class-name", "16Gi");
+    volumeRepository.getClaim(request);
+    volumeRepository.getClaim(request);
+
+    verify(pvcs, times(1)).create(any());
+  }
+
+  @Test
+  public void deletesClaimsOnClose() throws Exception {
+    VolumeRequest request1 = VolumeRequest.volumeRequest("storage-class-name", "16Gi").keepOnExit();
+    VolumeRequest request2 = VolumeRequest.volumeRequest("storage-class-name", "16Gi");
+    PersistentVolumeClaim claim1 = volumeRepository.getClaim(request1);
+    PersistentVolumeClaim claim2 = volumeRepository.getClaim(request2);
+
+    volumeRepository.close();
+    assertThat(deletedPvcs.getValue(), contains(claim2));
+  }
+}

--- a/hype-submitter_2.11/src/main/scala/com/spotify/hype/package.scala
+++ b/hype-submitter_2.11/src/main/scala/com/spotify/hype/package.scala
@@ -18,6 +18,11 @@ package object hype {
       model.VolumeRequest.volumeRequest(name, mountPath)
   }
 
+  object ExistingVolume {
+    def apply(claimName: String): model.VolumeRequest =
+      model.VolumeRequest.existingClaim(claimName)
+  }
+
   implicit def fnToHfn[T](fn: util.Fn[T]): HFn[T] = HFn(fn.run())
 
   implicit def toHfn[A](fn: () => A): HFn[A] = HFn(fn())

--- a/hype-submitter_2.11/src/main/scala/com/spotify/hype/package.scala
+++ b/hype-submitter_2.11/src/main/scala/com/spotify/hype/package.scala
@@ -14,8 +14,11 @@ package object hype {
   }
 
   object VolumeRequest {
-    def apply(name: String, mountPath: String): model.VolumeRequest =
-      model.VolumeRequest.volumeRequest(name, mountPath)
+    def apply(storageClass: String, mountPath: String): model.VolumeRequest =
+      model.VolumeRequest.volumeRequest(storageClass, mountPath)
+
+    def apply(id: String, storageClass: String, mountPath: String): model.VolumeRequest =
+      model.VolumeRequest.volumeRequest(id, storageClass, mountPath)
   }
 
   object ExistingVolume {


### PR DESCRIPTION
This adds two main features

- Mark a volume request to **not** be deleted on exit
```scala
val disk = VolumeRequest("gce-ssd-pd", "10Gi").keepOnExit
```

- Reference and existing claim instead of creating a new
```scala
val disk = ExistingVolume("hype-request-4fzih539")
```

replaces #31 
fixes #11