### PR TITLE
add retries to Kubernetes Docker Runner

### DIFF
--- a/hype-common/pom.xml
+++ b/hype-common/pom.xml
@@ -11,6 +11,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.esotericsoftware</groupId>
       <artifactId>kryo-shaded</artifactId>
       <version>4.0.0</version>

--- a/hype-common/src/main/java/com/spotify/hype/FluentBackoff.java
+++ b/hype-common/src/main/java/com/spotify/hype/FluentBackoff.java
@@ -16,7 +16,7 @@
  * -/-/-
  */
 
-package com.spotify.hype.gcs;
+package com.spotify.hype;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -132,7 +132,7 @@ public final class FluentBackoff {
    */
   public FluentBackoff withMaxCumulativeBackoff(Duration maxCumulativeBackoff) {
     checkArgument(maxCumulativeBackoff.isLongerThan(Duration.ZERO),
-        "maxCumulativeBackoff %s must be at least 1 millisecond", maxCumulativeBackoff);
+                                "maxCumulativeBackoff %s must be at least 1 millisecond", maxCumulativeBackoff);
     return new FluentBackoff(
         exponent, initialBackoff, maxBackoff, maxCumulativeBackoff, maxRetries);
   }

--- a/hype-common/src/main/java/com/spotify/hype/FluentBackoff.java
+++ b/hype-common/src/main/java/com/spotify/hype/FluentBackoff.java
@@ -132,7 +132,7 @@ public final class FluentBackoff {
    */
   public FluentBackoff withMaxCumulativeBackoff(Duration maxCumulativeBackoff) {
     checkArgument(maxCumulativeBackoff.isLongerThan(Duration.ZERO),
-                                "maxCumulativeBackoff %s must be at least 1 millisecond", maxCumulativeBackoff);
+        "maxCumulativeBackoff %s must be at least 1 millisecond", maxCumulativeBackoff);
     return new FluentBackoff(
         exponent, initialBackoff, maxBackoff, maxCumulativeBackoff, maxRetries);
   }

--- a/hype-gcs/pom.xml
+++ b/hype-gcs/pom.xml
@@ -11,6 +11,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>hype-common</artifactId>
+      <version>0.0.18-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
     </dependency>

--- a/hype-gcs/src/main/java/com/spotify/hype/gcs/StagingUtil.java
+++ b/hype-gcs/src/main/java/com/spotify/hype/gcs/StagingUtil.java
@@ -18,6 +18,7 @@
 
 package com.spotify.hype.gcs;
 
+
 import static com.google.cloud.storage.contrib.nio.CloudStorageOptions.withMimeType;
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static java.nio.file.StandardOpenOption.WRITE;
@@ -37,6 +38,7 @@ import com.google.common.io.Files;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import com.spotify.hype.FluentBackoff;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/hype-gcs/src/main/java/com/spotify/hype/gcs/StagingUtil.java
+++ b/hype-gcs/src/main/java/com/spotify/hype/gcs/StagingUtil.java
@@ -18,7 +18,6 @@
 
 package com.spotify.hype.gcs;
 
-
 import static com.google.cloud.storage.contrib.nio.CloudStorageOptions.withMimeType;
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static java.nio.file.StandardOpenOption.WRITE;

--- a/hype-submitter/src/main/java/com/spotify/hype/runner/KubernetesDockerRunner.java
+++ b/hype-submitter/src/main/java/com/spotify/hype/runner/KubernetesDockerRunner.java
@@ -118,9 +118,8 @@ public class KubernetesDockerRunner implements DockerRunner {
             retrySleeper.sleep(sleep);
           }
         } catch (IOException | InterruptedException ioe) {
-          LOG.error("Failed when trying to sleep: {}", ioe.getMessage(), ioe);
           throw new RuntimeException(
-              String.format("Failed when trying to sleep: {}", ioe.getMessage()), ioe);
+              String.format("Failed to create Kubernetes pod when trying to sleep: %s", ioe.getMessage()), ioe);
         }
       } catch (InterruptedException ie) {
         throw new RuntimeException("Interrupted while blocking", ie);


### PR DESCRIPTION
fixes https://github.com/spotify/hype/issues/34

Moved FluentBackoff to hype-common to be used for retries in both hype-submitter and hype-gcs packages.

@flylo @ravwojdyla or @yonromai PTAL 